### PR TITLE
Update lambda-zewotherm.yaml

### DIFF
--- a/templates/definition/charger/lambda-zewotherm.yaml
+++ b/templates/definition/charger/lambda-zewotherm.yaml
@@ -16,12 +16,12 @@ requirements:
       Energiemanagementeinstellungen am Gerät:
 
       - E-Meter Kommunikationsart: "ModBus Client"
-      - E-Meter Messpunkt: "Pos. E-Überschuss" oder "Neg. E-Überschuss"
+      - E-Meter Messpunkt: "E-Eintrag"
     en: |
       Energy management settings of the device:
 
       - E-Meter communication type: "ModBus Client"
-      - E-Meter measuring point: "Pos. Excess Energy" or "Neg. Excess Energy"
+      - E-Meter measuring point: "Energy-Input"
 params:
   - name: host
   - name: port
@@ -29,13 +29,6 @@ params:
   - name: tempsource
     type: choice
     choice: ["warmwater_top", "warmwater_bottom", "buffer_top", "buffer_bottom"]
-  - name: excess
-    type: choice
-    choice: ["plus", "minus"]
-    default: "plus"
-    description:
-      de: E-Überschuss ("plus" oder "minus")
-      en: Excess Energy ("plus" or "minus")
   - name: phases
     deprecated: true
   - name: watchdog
@@ -56,7 +49,7 @@ render: |
         address: 102 # PV Überschussleistung
         type: writemultiple # λ erwartet single value als FC16
         decode: int16
-      scale: {{ if eq .excess "plus" }}1{{ else }}-1{{ end }}
+      scale: 1
   power:
     source: modbus
     uri: {{ .host }}:{{ .port }}


### PR DESCRIPTION

as the setting "E-Eintrag" seems to be more appropriate for the Lambda heatpump I have edited the template file.
The setting E-Eintrag mostly disables the logic of the Lambda itself (except "softening" the received values, which is fine). The Lambda is allowed to consume the energy, that EVCC reports to it. It acts like a wallbox consuming the power, which is received by EVCC.

