### PR TITLE
Fzahn lambda excess deprecated

### DIFF
--- a/templates/definition/charger/lambda-zewotherm.yaml
+++ b/templates/definition/charger/lambda-zewotherm.yaml
@@ -33,6 +33,10 @@ params:
     deprecated: true
   - name: excess
     deprecated: true
+    default: "plus"
+    description:
+      de: E-Eintrag
+      en: Energy-Input
   - name: watchdog
     type: duration
     default: 60s

--- a/templates/definition/charger/lambda-zewotherm.yaml
+++ b/templates/definition/charger/lambda-zewotherm.yaml
@@ -31,6 +31,8 @@ params:
     choice: ["warmwater_top", "warmwater_bottom", "buffer_top", "buffer_bottom"]
   - name: phases
     deprecated: true
+  - name: excess
+    deprecated: true
   - name: watchdog
     type: duration
     default: 60s

--- a/templates/definition/charger/lambda-zewotherm.yaml
+++ b/templates/definition/charger/lambda-zewotherm.yaml
@@ -51,7 +51,6 @@ render: |
         address: 102 # PV Überschussleistung
         type: writemultiple # λ erwartet single value als FC16
         decode: int16
-      scale: 1
   power:
     source: modbus
     uri: {{ .host }}:{{ .port }}


### PR DESCRIPTION
Excess-Param remains in template, scale not needed